### PR TITLE
Added quicStatus to Info Metrics

### DIFF
--- a/storj_exporter/collectors.py
+++ b/storj_exporter/collectors.py
@@ -42,7 +42,7 @@ class NodeCollector(StorjCollector):
                 documentation='Storj node info',
                 data_dict=self._node,
                 data_keys=['nodeID', 'wallet', 'upToDate', 'version',
-                           'allowedVersion']
+                           'allowedVersion','quicStatus']
             ),
             GaugeMetricTemplate(
                 metric_name='storj_total_diskspace',


### PR DESCRIPTION
I added `quicStatus` so that we can also see them on the grafana dashboards.

### Original Storj Dashboard
![image](https://user-images.githubusercontent.com/4527862/213334495-b33fa838-bd02-46d3-bf18-4000bd6d6847.png)

### JSON
```bash
$ curl -s http://localhost:14002/api/sno/ | jq '.quicStatus'
"OK"
```

I wanted to extend the tests to cover this case. But I didn't manage to successfully reproduce the tests. (I got errors with a simple `pytest -v tests`.)

What do you think about this?
Would you like to merge this?

You can add tests, if you want to.

---

This is a duplicate of this older PR: https://github.com/anclrii/Storj-Exporter/pull/72
I created this new PR, as I added changes to master which I didn't want to merge.