### PR TITLE
Added timeout as env variable to avoid timeout on API Storj payout

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Following environment variables are available:
 | --- | --- | --- | --- |
 | STORJ_HOST_ADDRESS | Address of the storage node | storagenode | 127.0.0.1 |
 | STORJ_API_PORT | Storage node api port | 14002 | 14002 |
+| STORJ_API_TIMEOUT | Storage node api timeout | 90 | 90 |
 | STORJ_EXPORTER_PORT | A port that exporter opens to expose metrics on | 9651 | 9651 |
 | STORJ_COLLECTORS | A list of collectors | payout sat | payout sat |
 

--- a/storj_exporter/__main__.py
+++ b/storj_exporter/__main__.py
@@ -81,7 +81,7 @@ def main():
     baseurl = 'http://' + storj_host_address + ':' + storj_api_port
     logger.info(f'Starting storj exporter on port {storj_exporter_port}, '
                 f'connecting to {baseurl} with collectors {storj_collectors} enabled')
-    client = ApiClient(baseurl, timeout={storj_api_timeout})
+    client = ApiClient(baseurl, timeout=storj_api_timeout)
     node_collector = NodeCollector(client)
     logger.info('Registering node collector')
     REGISTRY.register(node_collector)

--- a/storj_exporter/__main__.py
+++ b/storj_exporter/__main__.py
@@ -65,6 +65,7 @@ def main():
     """Read in environment variables"""
     storj_host_address = os.environ.get('STORJ_HOST_ADDRESS', '127.0.0.1')
     storj_api_port = os.environ.get('STORJ_API_PORT', '14002')
+    storj_api_timeout = int(os.environ.get('STORJ_API_TIMEOUT', '90'))
     storj_exporter_port = int(os.environ.get('STORJ_EXPORTER_PORT', '9651'))
     storj_collectors = os.environ.get('STORJ_COLLECTORS', 'payout sat').split()
     log_level = os.environ.get('STORJ_EXPORTER_LOG_LEVEL', 'INFO').upper()
@@ -80,7 +81,7 @@ def main():
     baseurl = 'http://' + storj_host_address + ':' + storj_api_port
     logger.info(f'Starting storj exporter on port {storj_exporter_port}, '
                 f'connecting to {baseurl} with collectors {storj_collectors} enabled')
-    client = ApiClient(baseurl)
+    client = ApiClient(baseurl, timeout={storj_api_timeout})
     node_collector = NodeCollector(client)
     logger.info('Registering node collector')
     REGISTRY.register(node_collector)


### PR DESCRIPTION
Added timeout as env variable to avoid timeout on API Storj payout.
New Default 90s

Tip: You should increase your scrape_interval in prometheus to avoid saturation on your node